### PR TITLE
Add BLAKE2b hashing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## next
+- add BLAKE2b-256 hashing support
 
 ## [0.6.102] - 01-Apr-2025
 

--- a/core/README.md
+++ b/core/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/NemProject/nem.core.svg?branch=dev)](https://travis-ci.org/NemProject/nem.core)
 
 This Java package provides the cryptographic and serialization base methods used by [NEM](https://nemproject.github.io/nem-docs) nodes. To deploy a complete node please examine the [build script](../infra/docker).
+It now includes support for the modern BLAKE2b-256 hashing algorithm.
 
 ## Package Organization
 

--- a/core/src/main/java/org/nem/core/crypto/Hashes.java
+++ b/core/src/main/java/org/nem/core/crypto/Hashes.java
@@ -42,9 +42,20 @@ public class Hashes {
 	 * @return The hash of the concatenated inputs.
 	 * @throws CryptoException if the hash operation failed.
 	 */
-	public static byte[] ripemd160(final byte[]... inputs) {
-		return hash("RIPEMD160", inputs);
-	}
+        public static byte[] ripemd160(final byte[]... inputs) {
+                return hash("RIPEMD160", inputs);
+        }
+
+       /**
+        * Performs a BLAKE2b-256 hash of the concatenated inputs.
+        *
+        * @param inputs The byte arrays to concatenate and hash.
+        * @return The hash of the concatenated inputs.
+        * @throws CryptoException if the hash operation failed.
+        */
+       public static byte[] blake2b_256(final byte[]... inputs) {
+               return hash("BLAKE2B-256", inputs);
+       }
 
 	private static byte[] hash(final String algorithm, final byte[]... inputs) {
 		return ExceptionUtils.propagate(() -> {

--- a/core/src/test/java/org/nem/core/crypto/HashesTest.java
+++ b/core/src/test/java/org/nem/core/crypto/HashesTest.java
@@ -10,7 +10,8 @@ import org.nem.core.test.Utils;
 public class HashesTest {
 	private static final HashTester SHA3_256_TESTER = new HashTester(Hashes::sha3_256, 32);
 	private static final HashTester SHA3_512_TESTER = new HashTester(Hashes::sha3_512, 64);
-	private static final HashTester RIPEMD160_TESTER = new HashTester(Hashes::ripemd160, 20);
+       private static final HashTester RIPEMD160_TESTER = new HashTester(Hashes::ripemd160, 20);
+       private static final HashTester BLAKE2B_256_TESTER = new HashTester(Hashes::blake2b_256, 32);
 
 	// region sha3_256
 
@@ -89,12 +90,40 @@ public class HashesTest {
 	}
 
 	@Test
-	public void ripemd160GeneratesDifferentHashForDifferentInputs() {
-		// Assert:
-		RIPEMD160_TESTER.assertHashIsDifferentForDifferentInputs();
-	}
+        public void ripemd160GeneratesDifferentHashForDifferentInputs() {
+                // Assert:
+                RIPEMD160_TESTER.assertHashIsDifferentForDifferentInputs();
+        }
 
-	// endregion
+       // endregion
+
+       // region blake2b_256
+
+       @Test
+       public void blake2b_256HashHasExpectedByteLength() {
+               // Assert:
+               BLAKE2B_256_TESTER.assertHashHasExpectedLength();
+       }
+
+       @Test
+       public void blake2b_256GeneratesSameHashForSameInputs() {
+               // Assert:
+               BLAKE2B_256_TESTER.assertHashIsSameForSameInputs();
+       }
+
+       @Test
+       public void blake2b_256GeneratesSameHashForSameMergedInputs() {
+               // Assert:
+               BLAKE2B_256_TESTER.assertHashIsSameForSplitInputs();
+       }
+
+       @Test
+       public void blake2b_256GeneratesDifferentHashForDifferentInputs() {
+               // Assert:
+               BLAKE2B_256_TESTER.assertHashIsDifferentForDifferentInputs();
+       }
+
+       // endregion
 
 	// region different hash algorithm
 
@@ -110,11 +139,23 @@ public class HashesTest {
 		assertHashesAreDifferent(Hashes::sha3_256, Hashes::sha3_512);
 	}
 
-	@Test
-	public void sha3_512AndRipemd160GenerateDifferentHashForSameInputs() {
-		// Assert:
-		assertHashesAreDifferent(Hashes::sha3_512, Hashes::ripemd160);
-	}
+        @Test
+        public void sha3_512AndRipemd160GenerateDifferentHashForSameInputs() {
+                // Assert:
+                assertHashesAreDifferent(Hashes::sha3_512, Hashes::ripemd160);
+        }
+
+       @Test
+       public void blake2b_256AndSha3_256GenerateDifferentHashForSameInputs() {
+               // Assert:
+               assertHashesAreDifferent(Hashes::blake2b_256, Hashes::sha3_256);
+       }
+
+       @Test
+       public void blake2b_256AndRipemd160GenerateDifferentHashForSameInputs() {
+               // Assert:
+               assertHashesAreDifferent(Hashes::blake2b_256, Hashes::ripemd160);
+       }
 
 	private static void assertHashesAreDifferent(final Function<byte[], byte[]> hashFunction1,
 			final Function<byte[], byte[]> hashFunction2) {


### PR DESCRIPTION
## Summary
- implement `blake2b_256` in `Hashes`
- cover BLAKE2b hashing with tests
- document new algorithm in README and changelog

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684091c47064832cb25ee8f9545ade26